### PR TITLE
Change to use Unicode-aware ncursesw library instead of ncurses.

### DIFF
--- a/ncurses.go
+++ b/ncurses.go
@@ -17,7 +17,7 @@
 package ncurses
 
 // #cgo CFLAGS: -D_XOPEN_SOURCE -D_XOPEN_SOURCE_EXTENDED
-// #cgo LDFLAGS: -lncurses
+// #cgo LDFLAGS: -lncursesw
 //
 // #include <locale.h>
 // #include <ncurses.h>


### PR DESCRIPTION
This change uses libncursesw instead of libncurses, means that Unicode works (for me, on Fedora, anyway...).  Tested with...
```
win.MvAddStr(row, col, "\u2503")
```
